### PR TITLE
STM32F746IGT6-WaveShare-Core7XXI.md correction

### DIFF
--- a/boards/STM32F746IGT6-WaveShare-Core7XXI.md
+++ b/boards/STM32F746IGT6-WaveShare-Core7XXI.md
@@ -84,7 +84,7 @@ title: "STM32F746IGT6 - WaveShare Core7XXI"
     <tr>
         <td rowspan="4"><b>Connectivity</b></td>
         <td>Headers</td>
-        <td>2x 2x27 male dupont (2.54mm)</td>
+        <td>2x 2x40 male dupont (2mm)</td>
     </tr>
     <tr>
         <td>Specific</td>

--- a/boards/STM32F746IGT6-WaveShare-Core7XXI.md
+++ b/boards/STM32F746IGT6-WaveShare-Core7XXI.md
@@ -87,10 +87,6 @@ title: "STM32F746IGT6 - WaveShare Core7XXI"
         <td>2x 2x40 male dupont (2mm)</td>
     </tr>
     <tr>
-        <td>Specific</td>
-        <td>Serial (1x4 male dupont (2.54mm))</td>
-    </tr>
-    <tr>
         <td>Debug</td>
         <td>JTAG (20-pin IDC)</td>
     </tr>

--- a/boards/STM32F746IGT6-WaveShare-Core7XXI.md
+++ b/boards/STM32F746IGT6-WaveShare-Core7XXI.md
@@ -87,6 +87,10 @@ title: "STM32F746IGT6 - WaveShare Core7XXI"
         <td>2x 2x40 male dupont (2mm)</td>
     </tr>
     <tr>
+        <td>Specific</td>
+        <td>None</td>
+    </tr>
+    <tr>
         <td>Debug</td>
         <td>JTAG (20-pin IDC)</td>
     </tr>


### PR DESCRIPTION
Fix for headers specification, removed serial that is not present.