### PR TITLE
Make the primary text colour easier to read

### DIFF
--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -11,7 +11,7 @@ $color-page-background:   #ffffff;
 $color-page-frame:        #f8f8f8;
 $color-page-border:       #e8e8e8;
 
-$color-text-primary:      #727272;
+$color-text-primary:      #111111;
 $color-text-secondary:    #444444;
 $color-text-code:         #333333;
 $color-text-bold:         #222222;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -11,15 +11,15 @@ $color-page-background:   #ffffff;
 $color-page-frame:        #f8f8f8;
 $color-page-border:       #e8e8e8;
 
-$color-text-primary:      #111111;
-$color-text-secondary:    #444444;
-$color-text-code:         #333333;
-$color-text-bold:         #222222;
+$color-text-primary:      #2a2a2a;
+$color-text-secondary:    #222222;
+$color-text-code:         #333344;
+$color-text-bold:         #111111;
 $color-text-highlight:    #ffff00;
 
 // Color mappings
 $color-text-h1: $color-text-bold;
-$color-text-h2: $color-text-code;
+$color-text-h2: $color-text-secondary;
 $color-text-h3: $color-text-secondary;
 $color-text-h4: $color-text-secondary;
 $color-text-h5: $color-text-secondary;


### PR DESCRIPTION
Currently the primary text is coloured in relatively light gray. This PR changes it to be substantially darker and, hopefully, easier to read.

---

The following picture presents three text colour variants: `#727272` (current), `rgba(0, 0, 0, 0.87)` and `#000000`. This PR proposes `#111111`, which is somewhere between the latter ones.

![colours](https://user-images.githubusercontent.com/12767117/71580966-55a51580-2b03-11ea-9b58-a5a2c39eed3a.gif)