### PR TITLE
STM32F030F4P6-STM32F030F4-Minimal-System-Board-V2.0 User Led PB1 is sink

### DIFF
--- a/_data/boards/STM32F030F4P6-STM32F030F4-Minimal-System-Board-V2.0.json
+++ b/_data/boards/STM32F030F4P6-STM32F030F4-Minimal-System-Board-V2.0.json
@@ -115,7 +115,7 @@
             "function": "user",
             "type": "led",
             "to": "PB1",
-            "mode": "source"
+            "mode": "sink"
         }
     ],
     "connectors": [


### PR DESCRIPTION
STM32F030F4P6-STM32F030F4-Minimal-System-Board-V2.0 User Led PB1 is sink.
Checked with schematics and actual board.