### PR TITLE
Fix /CS pin of STM32F407ZGT6-STM32F4XX

### DIFF
--- a/_data/boards/STM32F407ZGT6-STM32F4XX.json
+++ b/_data/boards/STM32F407ZGT6-STM32F4XX.json
@@ -490,7 +490,7 @@
             },
             "footprint": false,
             "pins": [
-                { "number": 1, "name": null, "function": "/CS",   "to": "+3.3V rail via 10kΩ resistor" },
+                { "number": 1, "name": null, "function": "/CS",   "to": "PB14 with 10kΩ pull-up resistor" },
                 { "number": 2, "name": null, "function": "DO",    "to": "PB4" },
                 { "number": 3, "name": null, "function": "/WP",   "to": "3V3" },
                 { "number": 4, "name": null, "function": "GND",   "to": "GND" },


### PR DESCRIPTION
Hi, I noticed in the [STM32F4XX page](https://stm32-base.org/boards/STM32F407ZGT6-STM32F4XX), the external FLASH chip [W25Q16JV](https://stm32-base.org/boards/STM32F407ZGT6-STM32F4XX#W25Q16JV) section, doesn't mention that the chip select pin (/CS) is connected to PB14 on the STM32 (its the `F_CS` net on the  [original schematic](https://stm32-base.org/assets/pdf/boards/original-schematic-STM32F407ZET6-STM32F4XX.pdf)).

I also removed the reference to the +3V3 net by phrasing as a 10k pull-up. Do you think its better like this or to keep all the original wording?