### PR TITLE
Update STM32F407VET6-STM32-F4VE-V2.0.json

### DIFF
--- a/_data/boards/STM32F407VET6-STM32-F4VE-V2.0.json
+++ b/_data/boards/STM32F407VET6-STM32-F4VE-V2.0.json
@@ -264,7 +264,7 @@
                 { "number": 3,  "name": "3V3",  "function": null, "to": "3V3" },
                 { "number": 4,  "name": "3V3",  "function": null, "to": "3V3" },
                 { "number": 5,  "name": "BT0",  "function": null, "to": "BOOT0" },
-                { "number": 6,  "name": "BT1",  "function": null, "to": "PE2" },
+                { "number": 6,  "name": "BT1",  "function": null, "to": "PB2" },
                 { "number": 7,  "name": "GND",  "function": null, "to": "GND" },
                 { "number": 8,  "name": "GND",  "function": null, "to": "GND" },
                 { "number": 9,  "name": "GND",  "function": null, "to": "GND" },


### PR DESCRIPTION
PE2 -> PB2 according to schematic

Fix #46

<img width="379" height="88" alt="image" src="https://github.com/user-attachments/assets/4b40b7d8-4d17-4eb2-9282-4d97ae5961a6" />
